### PR TITLE
Fix #14: Session subtitle truncated on main screen

### DIFF
--- a/app/src/main/res/layout/main_session_list_item.xml
+++ b/app/src/main/res/layout/main_session_list_item.xml
@@ -7,8 +7,9 @@
     <LinearLayout
         android:orientation="vertical"
         android:padding="10dp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1">
         <TextView
             android:id="@+id/spinnerText1"
             android:layout_width="wrap_content"
@@ -18,6 +19,8 @@
             android:id="@+id/spinnerText2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:text="Small Text"/>
     </LinearLayout>
     <Space


### PR DESCRIPTION
## Changes
- Inner LinearLayout: `wrap_content` → `0dp` + `layout_weight=1` to fill available width
- Subtitle: added `maxLines=2` + `ellipsize=end` as safety net

Closes #14